### PR TITLE
Put post content under a top-level "article" key for creates and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-devto" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.0.12
+
+- Add top-level "article" key to body of create/update calls
+
 ## 0.0.11
 
 - Add upload images to Imgur

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-devto",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "DEV Community",
   "description": "DEV Community",
   "publisher": "sneezry",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "icon": "resources/DEV.png",
   "preview": true,
   "galleryBanner": {

--- a/src/api/DevApi.ts
+++ b/src/api/DevApi.ts
@@ -14,7 +14,7 @@ export interface Article {
 export class DevAPI {
   constructor(private _apiKey?: string) {}
 
-  private _buildRequestOptions(path: string, method: string, parameters?: {[key: string]: string|number}, artical?: Article) {
+  private _buildRequestOptions(path: string, method: string, parameters?: {[key: string]: string|number}, article?: Article) {
     let uri = `https://dev.to/api${path}`;
     if (parameters) {
       let query: string[] = [];
@@ -32,8 +32,8 @@ export class DevAPI {
       json: true,
     };
 
-    if (artical) {
-      options.body = artical;
+    if (article) {
+      options.body = { article };
     }
 
     return options;


### PR DESCRIPTION
Hi and thanks a lot for this handy extension! I used it recently for the first time in a couple months and was getting an error when creating or updating posts:

```
Failed to save '<my article>'.md: 422 - {"error":"article param must be a JSON object. You provided article as a NilClass","status":422}
```

This PR addresses that issue.